### PR TITLE
Switch to container action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,10 @@ jobs:
 
     - name: Validate source rpm files
       run: |
+        set -e
+        ls -l "${{ steps.srpm.outputs.path }}"
+        rpm -qlp "${{ steps.srpm.outputs.path }}"
+
         for file in $(rpm -qlp ${{ steps.srpm.outputs.path }}); do
           echo $file | grep -e 'test\.spec' -e 'readme\.md' -e 'readme2\.md' -e 'action-build-srpm-1.tar.gz'
         done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,12 +22,12 @@ jobs:
         cat <<EOF > test.spec
         Name:           action-build-srpm
         Version:        1
-        Release:        1%{?dist}
+        Release:        %autorelease
         Summary:        Test action-build-srpm
         URL:            https://github.com/next-actions/action-build-srpm
 
         License:        GPLv3+
-        Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
+        Source0:        %{url}/archive/%{version}/%{name}-%{version_no_tilde}.tar.gz
         Source1:        readme.md
         Source2:        readme2.md
 
@@ -44,6 +44,9 @@ jobs:
 
         %files
         %{_bindir}/test.sh
+
+        %changelog
+        %autochangelog
         EOF
 
     - name: Build source rpm

--- a/action.yml
+++ b/action.yml
@@ -13,52 +13,12 @@ inputs:
 outputs:
   path:
     description: Path to the created source rpm
-    value: ${{ steps.result.outputs.path }}
   file:
     description: File name to the created source rpm
-    value: ${{ steps.result.outputs.file }}
 runs:
-  using: 'composite'
-  steps:
-    - name: Prepare rpm directory structure
-      id: buildroot
-      shell: bash
-      run: |
-        dir=`mktemp -d`
-
-        mkdir -p $dir/rpmbuild/BUILD
-        mkdir -p $dir/rpmbuild/RPMS
-        mkdir -p $dir/rpmbuild/SOURCES
-        mkdir -p $dir/rpmbuild/SPECS
-        mkdir -p $dir/rpmbuild/SRPMS
-
-        echo "path=$dir/rpmbuild" >> $GITHUB_OUTPUT
-
-    - name: Move tarball to rpm buildroot
-      shell: bash
-      run: |
-        cp ${{ inputs.tarball }} ${{ steps.buildroot.outputs.path }}/SOURCES/
-
-    - name: Copy source files to rpm buildroot
-      env:
-        files: ${{ inputs.sourcefiles }}
-      shell: bash
-      run: |
-        for file in $files; do
-          cp $file ${{ steps.buildroot.outputs.path }}/SOURCES/
-        done
-
-    - name: Build source rpm
-      id: build
-      shell: bash
-      run: |
-        rpmbuild --define "_topdir ${{ steps.buildroot.outputs.path }}" -bs ${{ inputs.specfile }}
-
-    - name: Set output srpm path
-      id: result
-      shell: bash
-      run: |
-        path=`ls ${{ steps.buildroot.outputs.path }}/SRPMS/*.rpm`
-        file=`basename $path`
-        echo "path=$path" >> $GITHUB_OUTPUT
-        echo "file=$file" >> $GITHUB_OUTPUT
+  using: 'docker'
+  image: 'container/Dockerfile'
+  args:
+  - ${{ inputs.tarball }}
+  - ${{ inputs.specfile }}
+  - ${{ inputs.sourcefiles }}

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,0 +1,4 @@
+FROM fedora:latest
+RUN dnf install -y rpmbuild && dnf clean all
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -ex
+
+tarball=$1
+specfile=$2
+files=$3
+
+echo "::group::Prepare rpm directory structure"
+tmpdir=`mktemp -p /github/workspace -d`
+dir=$tmpdir/rpmbuild
+mkdir -p "$dir/BUILD"
+mkdir -p "$dir/RPMS"
+mkdir -p "$dir/SOURCES"
+mkdir -p "$dir/SPECS"
+mkdir -p "$dir/SRPMS"
+echo "::endgroup::"
+
+echo "::group::Move tarball to rpm buildroot"
+cp "$tarball" "$dir/SOURCES/"
+echo "::endgroup::"
+
+echo "::group::Copy source files to rpm buildroot"
+for file in $files; do
+    cp "$file" "$dir/SOURCES/"
+done
+echo "::endgroup::"
+
+echo "::group::Build source rpm"
+rpmbuild --define "_topdir $dir" -bs "$specfile"
+echo "::endgroup::"
+
+echo "::group::Set output srpm path"
+chmod -R a+rwx "$tmpdir"
+path=`ls $dir/SRPMS/*.rpm`
+path=${path#/github/workspace/}
+file=`basename $path`
+echo "path=$path" >> $GITHUB_OUTPUT
+echo "file=$file" >> $GITHUB_OUTPUT
+echo "::endgroup::"


### PR DESCRIPTION
Ubuntu runner does not have the same set of macros available as Fedora,
let's do the rpmbuild inside a Fedora container.